### PR TITLE
bugfix favicon redirect after successful login

### DIFF
--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/configuration/SecurityConfiguration.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/configuration/SecurityConfiguration.java
@@ -1,10 +1,12 @@
-package ch.bfh.bti7081.s2020.blue.security;
+package ch.bfh.bti7081.s2020.blue.configuration;
 
 import ch.bfh.bti7081.s2020.blue.domain.Login;
+import ch.bfh.bti7081.s2020.blue.security.FrameworkIgnoringRequestCache;
 import ch.bfh.bti7081.s2020.blue.util.SecurityUtils;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -13,6 +15,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   private final UserDetailsService databaseUserDetailsService;
@@ -53,8 +56,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   public void configure(WebSecurity web) {
-    web.debug(true);
-
     web.ignoring().antMatchers(
         // Vaadin Flow static resources //
         "/VAADIN/**",

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Achievement.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Achievement.java
@@ -8,15 +8,15 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Achievement {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Challenge.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Challenge.java
@@ -9,12 +9,14 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Builder
 @NoArgsConstructor

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/JournalEntry.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/JournalEntry.java
@@ -10,12 +10,14 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Builder
 @NoArgsConstructor

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Login.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Login.java
@@ -9,18 +9,24 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Login implements UserDetails {
+
+  public static final transient PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
   @Id
   private String username;

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Patient.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Patient.java
@@ -12,12 +12,14 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Builder
 @NoArgsConstructor

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Reward.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Reward.java
@@ -8,15 +8,15 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Reward {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Therapist.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/Therapist.java
@@ -5,15 +5,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-@Data
+@Getter
+@Setter
 @Entity
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Therapist {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientchallenge/PatientHasChallenge.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientchallenge/PatientHasChallenge.java
@@ -8,13 +8,13 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @Entity
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @IdClass(PatientHasChallengeId.class)

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientchallenge/PatientHasChallengeId.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientchallenge/PatientHasChallengeId.java
@@ -4,10 +4,12 @@ import ch.bfh.bti7081.s2020.blue.domain.Challenge;
 import ch.bfh.bti7081.s2020.blue.domain.Patient;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PatientHasChallengeId implements Serializable {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientreward/PatientAchieved.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientreward/PatientAchieved.java
@@ -8,13 +8,13 @@ import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @Entity
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @IdClass(PatientAchievedId.class)

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientreward/PatientAchievedId.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/association/patientreward/PatientAchievedId.java
@@ -4,10 +4,12 @@ import ch.bfh.bti7081.s2020.blue.domain.Achievement;
 import ch.bfh.bti7081.s2020.blue.domain.Patient;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PatientAchievedId implements Serializable {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/dto/RegisterDto.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/dto/RegisterDto.java
@@ -3,10 +3,12 @@ package ch.bfh.bti7081.s2020.blue.domain.dto;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegisterDto {

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/dto/ValidationError.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/domain/dto/ValidationError.java
@@ -1,9 +1,13 @@
 package ch.bfh.bti7081.s2020.blue.domain.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ValidationError {
 

--- a/source/src/main/java/ch/bfh/bti7081/s2020/blue/security/FrameworkIgnoringRequestCache.java
+++ b/source/src/main/java/ch/bfh/bti7081/s2020/blue/security/FrameworkIgnoringRequestCache.java
@@ -8,7 +8,7 @@ import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 /**
  * HttpSessionRequestCache that avoids saving internal framework requests.
  */
-class FrameworkIgnoringRequestCache extends HttpSessionRequestCache {
+public class FrameworkIgnoringRequestCache extends HttpSessionRequestCache {
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
This PR contains the following changes:
* refactor security configuration to use default values for login/-out urls
* also update lombok @Data classes, so it does no longer generate #toString nor #hasCode. this caused stackoverflows in recursive entity relations.

Please try it on your machine and give feedback ;)