### PR TITLE
Bugfix/#48 configure sonar cloud maven analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 dist: bionic
 
-install: true
+install: skip
 os: linux
 
 if: tag is blank
@@ -9,26 +9,11 @@ if: tag is blank
 notifications:
   email: false
 
-services:
-  - postgresql
-
 addons:
-  postgresql: '12'
   apt:
     packages:
       - postgresql-12
       - postgresql-client-12
-
-before_install:
-  - sudo pg_dropcluster --stop 12 main
-  - sudo pg_upgradecluster 11 main
-  - sudo pg_ctlcluster 12 main restart
-  - sudo pg_dropcluster 11 main
-
-env:
-  global:
-    - PGUSER=postgres
-    - PGPORT=5432
 
 jobs:
   include:
@@ -38,6 +23,11 @@ jobs:
     # OpenJDK - Java 13 (latest)
     - env: MAIN_BUILD='false'
       jdk: openjdk13
+
+before_install:
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/12/main/postgresql.conf
+  - sudo cp /etc/postgresql/{9.3,12}/main/pg_hba.conf
+  - sudo pg_ctlcluster 12 main restart
 
 before_script:
   - psql -c "CREATE DATABASE social_anxiety_integration;" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ addons:
     packages:
       - postgresql-12
       - postgresql-client-12
+  sonarcloud:
+    organization: "zeroplexer"
+    token:
+      secure: "uNQvxJ+5icIOybiWdcOLdy3Ysyfzfw3XADqwxV5P2p/8N86hOJFhGWpzEgW9khpBK+dKSUPmUfWX2I7gll8R4ZGX5xQ6nO0y5E784afi5u/HPGRCrYLyPBD9pANLZyRmrfhWVia8r+/pN+t0pgEi/cvAkbqBQC3SlRTpog5XGjIjVC6IoNspdewoheTSHRqYIt8kLPckc0RNspoI8IiTUGBvVw+dpg+lxTr8iwjY6P1Oj39Bi0blDlab1EMLixYxauM0u3Kv+nu/6ncEk0aDhOqLqIsb7ykre1OgTukHjgA2V6z+DoJfKaMlJIxy3C61887ywhbZiYC94EW3/4b/9rFc5Lv03G/u7nYusC01GAOOH0GaKzxBgMkGm8m/SDnRgNuex7qAQmWF77Ic6OtYV6dq03/0+Nrfi5HiYhhkIVZnszwX2xShxzG+d3pHRa4P93BeeGqXOhTrkv0wELc7+2+QokzLcbKNN5G5ZcRdYy83Ius8oN87/iAxIQj0MjJoQ4NIya3ABWRvgUGckQ50gzDMRCOl6Tf8kfT7ICEVPVTxv/r5SsRRkQ+vjIhkPDNvqMgH0k4NYxp9YvW9rE8xJxcyqp2boDUlOzEwGCsHgmRA/ESVAV/S9leaTfXrzNLd72EkKXXtGUqmztJIuXfpTz6SEioLsraf62AYDo0wN2g="
 
 jobs:
   include:
@@ -36,8 +40,9 @@ before_script:
 script:
   - if [[ "${MAIN_BUILD}" != "" && "${MAIN_BUILD}" == "true" ]]; then export MAVEN_COMMAND="verify"; else export MAVEN_COMMAND="verify"; fi
   - mvn -f source/pom.xml versions:set -DnewVersion=${TRAVIS_BUILD_NUMBER}
-  - mvn -f source/pom.xml ${MAVEN_COMMAND}
+  - mvn -f source/pom.xml ${MAVEN_COMMAND} sonar:sonar
 
 cache:
   directories:
     - $HOME/.m2
+    - $HOME/.sonar/cache

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -53,10 +53,14 @@
     <!-- Vaadin configuration -->
     <vaadin.version>14.1.27</vaadin.version>
 
+    <!-- Sonarcloud configuration -->
+    <sonar.projectKey>zeroplexer_ch.bfh.bti7081.s2020.blue</sonar.projectKey>
+
     <!-- Dependency management -->
     <lombok.version>1.18.12</lombok.version>
     <jupiter.version>5.6.2</jupiter.version>
     <mockito-core.version>3.3.3</mockito-core.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 
     <!-- Flyway configuration -->
     <flyway.db.url>jdbc:postgresql://localhost:${flyway.db.port}</flyway.db.url>
@@ -336,6 +340,30 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+
+          <execution>
+            <id>report</id>
+
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
it's actually just the changes in `travis-ci.yml` but I've also merged #54 into this branch for the faster builds! so, please merge #54 first.
the [analysis](https://sonarcloud.io/dashboard?branch=bugfix%2F%2348-configure-sonar-cloud-maven-analysis&id=zeroplexer_ch.bfh.bti7081.s2020.blue) now also includes all java sources (and no js sources). like it should. by the way, it would work with sonar-github integration if the maven project was located in the root directory. but it's ok this way too.